### PR TITLE
feat: API Core 추가작성 및 api 스펙별로 core기반 추가

### DIFF
--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -1,0 +1,17 @@
+import { ApiContext, api } from './core';
+
+export interface Channel {
+  channelId: number;
+  name: string;
+  playerCount: number;
+  maxPlayers: number;
+}
+
+interface GetChannelResponse {
+  channels: Channel[];
+}
+
+export const getChannelsAPI = async (ctx?: ApiContext) => {
+  const { channels } = await api<GetChannelResponse>('/channel', {}, ctx);
+  return channels;
+};

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -1,0 +1,37 @@
+// lib/api.ts
+import {
+  getCookie as getClientCookie,
+  getCookie as getServerCookie,
+} from 'cookies-next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const COOKIE_NAME = 'accessToken';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL!;
+
+export type ApiContext = {
+  req: NextApiRequest;
+  res: NextApiResponse;
+};
+
+export async function api<T>(
+  path: string,
+  init?: RequestInit,
+  ctx?: ApiContext,
+): Promise<T> {
+  const url = `${BASE_URL}/${path}`;
+
+  const cookieValue = ctx
+    ? (getServerCookie(COOKIE_NAME, { req: ctx.req, res: ctx.res }) as string)
+    : (getClientCookie(COOKIE_NAME) as string);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(cookieValue && { cookie: cookieValue }),
+    ...(init?.headers as Record<string, string>),
+  };
+
+  const res = await fetch(url, { ...init, headers });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.message || res.statusText);
+  return data as T;
+}

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -28,7 +28,6 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   response => response,
   error => {
-    // if (error.response && error.response.status === 401) {}
     return Promise.reject(error.response?.data || error.message);
   },
 );

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,43 @@
+import { type ApiContext, api } from './core';
+
+interface LoginForm {
+  username: string;
+  password: string;
+}
+
+interface Member {
+  username: string;
+  memberType: string;
+  inLobby: boolean;
+  roomStatus: null | 'WAITING' | 'IN_PROGRESS' | 'END';
+}
+
+export const userNicknameAPI = (ctx?: ApiContext) =>
+  api<{ nickname: string }>('/member/nickname', { method: 'GET' }, ctx);
+
+export const guestLoginAPI = (ctx?: ApiContext) =>
+  api<{ token: string }>('/member/guest/login', { method: 'GET' }, ctx);
+
+export const userLoginAPI = (loginForm: LoginForm, ctx?: ApiContext) =>
+  api<{ token: string }>(
+    '/member/user/login',
+    { method: 'POST', body: JSON.stringify(loginForm) },
+    ctx,
+  );
+
+export const userSignupAPI = (loginForm: LoginForm, ctx?: ApiContext) =>
+  api<{ token: string }>(
+    '/member/user/signup',
+    { method: 'POST', body: JSON.stringify(loginForm) },
+    ctx,
+  );
+
+// 채널 내 유저 목록 조회
+export const getChannelUsersAPI = (channelId: string, ctx?: ApiContext) =>
+  api<{ users: Member[] }>(
+    `/member/${channelId}`,
+    {
+      method: 'GET',
+    },
+    ctx,
+  );

--- a/src/api/room.ts
+++ b/src/api/room.ts
@@ -1,0 +1,103 @@
+import { Mode } from '@/types/websocket';
+
+import { ApiContext, api } from './core';
+
+interface RoomForm {
+  channelId: number;
+  title: string;
+  password: string;
+  format: string;
+  gameModes: string[];
+  selectedYears: number[];
+}
+
+interface Room {
+  id: string;
+  title: string;
+  hostName: string;
+  format: 'GENERAL' | 'BOARD';
+  maxPlayer: number;
+  currentPlayers: number;
+  maxGameRound: number;
+  playTime: number;
+  status: 'WAITING' | 'PLAYING' | 'END';
+  roomNumber: number;
+  channelId: number;
+  hasPassword: boolean;
+  gameModes: Mode[];
+  years: number[];
+}
+
+export const createRoomAPI = (roomForm: RoomForm, ctx?: ApiContext) =>
+  api<{ roomId: string }>(
+    '/room',
+    {
+      method: 'POST',
+      body: JSON.stringify(roomForm),
+    },
+    ctx,
+  );
+
+export const getRoomsAPI = (
+  channelId: number,
+  page: number,
+  ctx?: ApiContext,
+) =>
+  api<{ content: Room[] }>(
+    `/room?channelId=${channelId}&page=${page}&size=6`,
+    { method: 'GET' },
+    ctx,
+  );
+
+export const patchRoomAPI = (roomForm: RoomForm, ctx?: ApiContext) =>
+  api(
+    '/room',
+    {
+      method: 'PATCH',
+      body: JSON.stringify(roomForm),
+    },
+    ctx,
+  );
+
+export const enterRoomAPI = (
+  roomId: string,
+  password: string,
+  ctx?: ApiContext,
+) =>
+  api<{ roomId: string }>(
+    `/room/enter`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        roomId,
+        password,
+      }),
+    },
+    ctx,
+  );
+
+// 제목으로 검색
+export const searchRoomByTitleAPI = (
+  title: string,
+  channelId: string,
+  ctx?: ApiContext,
+) =>
+  api<{ content: Room[] }>(
+    `/room/search/title?title=${title}&channelId=${channelId}`,
+    {
+      method: 'GET',
+    },
+    ctx,
+  );
+
+// 방 번호로 검색
+export const searchRoomByRoomNumberAPI = (
+  roomNumber: number,
+  channelId: string,
+  ctx?: ApiContext,
+) =>
+  api<{ content: Room[] }>(
+    `/room/search/number?roomNumber=${roomNumber}&channelId=${channelId}`,
+    { method: 'GET' },
+    ctx,
+  );

--- a/src/stores/auth/useNicknameStore.ts
+++ b/src/stores/auth/useNicknameStore.ts
@@ -4,13 +4,9 @@ interface NicknameStore {
   nickname: string;
   setNickname: (nickname: string) => void;
 }
-export const useNicknameStore = create<NicknameStore>((set, get) => ({
+export const useNicknameStore = create<NicknameStore>(set => ({
   nickname: '',
   setNickname: (newNickname: string) => {
-    const currentNickname = get().nickname;
-
-    if (currentNickname !== newNickname) {
-      set({ nickname: newNickname });
-    }
+    set({ nickname: newNickname });
   },
 }));


### PR DESCRIPTION
### 설명서

```js
export const userNicknameAPI = (ctx?: ApiContext) =>
  api<{ nickname: string }>('/member/nickname', { method: 'GET' }, ctx);
```

일단 여기 보면 `ctx` 라는걸 매개변수로 넘기는데 이건 serverSideProps에서 res / req 넘겨주면 돼 

```ts

export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
  // req: NextApiRequest, res: NextApiResponse
  const ctx: ApiContext = { req, res };
  try {
    const token = await userNicknameAPI(ctx);
    return { props: { token } };
  } catch (err: any) {
    return { props: { error: err.message } };
  }
};
```

뭐 이런식으로 쓰는거지 ?? 

저걸 왜 매개변수로 넘겨주냐면 api core에서 쿠키에 접근해서 토큰을 가져와야하는데, 이게 api요청을 클라이언트에서 하는지 서버에서 하는지 몰라서 저렇게해야하더라 

닉네임 하나때문이긴한데, serverSideProps에서 토큰으로 닉네임 받아오고 그 닉네임 계속 사용하려고 하는방식이긴해 
그냥 서버사이드에서 api 요청안보낼거고 무조건 클라이언트에서 보내는 방식도 있긴한데 그러면 실제로 useEffect안에서 window처리 하고 쿠키 다 꺼내서 닉네임 조회하고 닉네임으로 화면 만들고 하는 방식으로 하면 되긴하는데, 선택의 문제일 듯 ?? 

결론 : 
확장성면에서는 ctx를 쓰는게 맞는것 같고 그거 아니다, 그냥 cookie에서 토큰 꺼내서 serverSideProps로 페이지에 전달해주면 토큰으로 닉네임 useEffect(클라이언트 사이드)에서 쏴서 전역상태로 관리하면 된다. 싶으면 그렇게 가면 될 것 같아. 편한대로 리뷰주면 그거 반영해서 수정해줄게 