### PR TITLE
Feat/user nickname/son

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,20 @@
+import { UserCredentials } from '@/hooks/useAuth';
+
+import { ApiContext, api } from './core';
+
+export const guestLoginAPI = (ctx?: ApiContext) =>
+  api<{ accessToken: string }>('/auth/guest', { method: 'GET' }, ctx);
+
+export const userLoginAPI = (loginForm: UserCredentials, ctx?: ApiContext) =>
+  api<{ accessToken: string }>(
+    '/auth/login',
+    { method: 'POST', body: JSON.stringify(loginForm) },
+    ctx,
+  );
+
+export const userSignupAPI = (loginForm: UserCredentials, ctx?: ApiContext) =>
+  api<{ accessToken: string }>(
+    '/auth/signup',
+    { method: 'POST', body: JSON.stringify(loginForm) },
+    ctx,
+  );

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -1,37 +1,67 @@
-// lib/api.ts
 import {
   getCookie as getClientCookie,
   getCookie as getServerCookie,
 } from 'cookies-next';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-const COOKIE_NAME = 'accessToken';
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL!;
+export const COOKIE_NAME = 'accessToken';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export type ApiContext = {
   req: NextApiRequest;
   res: NextApiResponse;
 };
 
+type ApiSuccess<T> = {
+  success: true;
+  data: T;
+  error: null;
+};
+
+type ApiFail = {
+  success: false;
+  data: null;
+  error: string;
+};
+
+export type ApiResponse<T> = ApiSuccess<T> | ApiFail;
+
 export async function api<T>(
   path: string,
   init?: RequestInit,
   ctx?: ApiContext,
-): Promise<T> {
-  const url = `${BASE_URL}/${path}`;
+): Promise<ApiResponse<T>> {
+  const url = `${BASE_URL}${path}`;
 
   const cookieValue = ctx
-    ? (getServerCookie(COOKIE_NAME, { req: ctx.req, res: ctx.res }) as string)
-    : (getClientCookie(COOKIE_NAME) as string);
+    ? ((await getServerCookie(COOKIE_NAME, {
+        req: ctx.req,
+        res: ctx.res,
+      })) as string)
+    : ((await getClientCookie(COOKIE_NAME)) as string);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    ...(cookieValue && { cookie: cookieValue }),
+    ...(cookieValue && { Authorization: 'Bearer ' + cookieValue }),
     ...(init?.headers as Record<string, string>),
   };
 
+  console.log('headers:', headers);
+
   const res = await fetch(url, { ...init, headers });
   const data = await res.json();
-  if (!res.ok) throw new Error(data.message || res.statusText);
-  return data as T;
+
+  if (!res.ok) {
+    return {
+      data: null,
+      success: false,
+      error: data.message || res.statusText,
+    };
+  }
+
+  return {
+    data: data as T,
+    success: true,
+    error: null,
+  };
 }

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,38 +1,15 @@
 import { type ApiContext, api } from './core';
 
-interface LoginForm {
+export interface Member {
   username: string;
-  password: string;
-}
-
-interface Member {
-  username: string;
-  memberType: string;
+  memberType: 'GUEST' | 'USER';
   inLobby: boolean;
-  roomStatus: null | 'WAITING' | 'IN_PROGRESS' | 'END';
+  roomStatus: 'WAITING' | 'IN_PROGRESS' | null;
 }
 
 export const userNicknameAPI = (ctx?: ApiContext) =>
-  api<{ nickname: string }>('/member/nickname', { method: 'GET' }, ctx);
+  api<{ username: string }>('/auth/me', { method: 'GET' }, ctx);
 
-export const guestLoginAPI = (ctx?: ApiContext) =>
-  api<{ token: string }>('/member/guest/login', { method: 'GET' }, ctx);
-
-export const userLoginAPI = (loginForm: LoginForm, ctx?: ApiContext) =>
-  api<{ token: string }>(
-    '/member/user/login',
-    { method: 'POST', body: JSON.stringify(loginForm) },
-    ctx,
-  );
-
-export const userSignupAPI = (loginForm: LoginForm, ctx?: ApiContext) =>
-  api<{ token: string }>(
-    '/member/user/signup',
-    { method: 'POST', body: JSON.stringify(loginForm) },
-    ctx,
-  );
-
-// 채널 내 유저 목록 조회
 export const getChannelUsersAPI = (channelId: string, ctx?: ApiContext) =>
   api<{ users: Member[] }>(
     `/member/${channelId}`,

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -11,7 +11,7 @@ export const userNicknameAPI = (ctx?: ApiContext) =>
   api<{ username: string }>('/auth/me', { method: 'GET' }, ctx);
 
 export const getChannelUsersAPI = (channelId: string, ctx?: ApiContext) =>
-  api<{ users: Member[] }>(
+  api<{ userList: Member[] }>(
     `/member/${channelId}`,
     {
       method: 'GET',

--- a/src/api/room.ts
+++ b/src/api/room.ts
@@ -1,15 +1,7 @@
+import { RoomApiRequestData } from '@/components/room/utils/roomDataConverter';
 import { Mode } from '@/types/websocket';
 
 import { ApiContext, api } from './core';
-
-interface RoomForm {
-  channelId: number;
-  title: string;
-  password: string;
-  format: string;
-  gameModes: string[];
-  selectedYears: number[];
-}
 
 interface Room {
   id: string;
@@ -28,7 +20,7 @@ interface Room {
   years: number[];
 }
 
-export const createRoomAPI = (roomForm: RoomForm, ctx?: ApiContext) =>
+export const createRoomAPI = (roomForm: RoomApiRequestData, ctx?: ApiContext) =>
   api<{ roomId: string }>(
     '/room',
     {
@@ -39,18 +31,18 @@ export const createRoomAPI = (roomForm: RoomForm, ctx?: ApiContext) =>
   );
 
 export const getRoomsAPI = (
-  channelId: number,
+  channelId: string,
   page: number,
   ctx?: ApiContext,
 ) =>
-  api<{ content: Room[] }>(
+  api<{ content: Room[]; number: number; totalPages: number }>(
     `/room?channelId=${channelId}&page=${page}&size=6`,
     { method: 'GET' },
     ctx,
   );
 
-export const patchRoomAPI = (roomForm: RoomForm, ctx?: ApiContext) =>
-  api(
+export const patchRoomAPI = (roomForm: RoomApiRequestData, ctx?: ApiContext) =>
+  api<{ roomId: string }>(
     '/room',
     {
       method: 'PATCH',
@@ -64,7 +56,7 @@ export const enterRoomAPI = (
   password: string,
   ctx?: ApiContext,
 ) =>
-  api<{ roomId: string }>(
+  api<{ roomId: string; success: boolean }>(
     `/room/enter`,
     {
       method: 'POST',
@@ -82,7 +74,7 @@ export const searchRoomByTitleAPI = (
   channelId: string,
   ctx?: ApiContext,
 ) =>
-  api<{ content: Room[] }>(
+  api<{ content: Room[]; number: number; totalPages: number }>(
     `/room/search/title?title=${title}&channelId=${channelId}`,
     {
       method: 'GET',
@@ -90,13 +82,12 @@ export const searchRoomByTitleAPI = (
     ctx,
   );
 
-// 방 번호로 검색
 export const searchRoomByRoomNumberAPI = (
   roomNumber: number,
   channelId: string,
   ctx?: ApiContext,
 ) =>
-  api<{ content: Room[] }>(
+  api<{ content: Room[]; number: number; totalPages: number }>(
     `/room/search/number?roomNumber=${roomNumber}&channelId=${channelId}`,
     { method: 'GET' },
     ctx,

--- a/src/components/auth/AccountFormDialog.tsx
+++ b/src/components/auth/AccountFormDialog.tsx
@@ -16,7 +16,7 @@ import SignupForm from './SignupForm';
 export default function AccountFormDialog() {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('login');
-  const [signupUsername, setSignupUsername] = useState<string>('');
+  const [signupUsername, setSignupUsername] = useState('');
 
   useEffect(() => {
     if (!open) {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -11,8 +11,8 @@ import { Input } from '@/components/ui/input';
 import { useLoginForm } from '@/hooks/useLoginForm';
 
 interface LoginFormProps {
-  onSuccess?: () => void;
-  initialUsername?: string;
+  onSuccess: () => void;
+  initialUsername: string;
 }
 
 export default function LoginForm({

--- a/src/components/room/RoomContainer.tsx
+++ b/src/components/room/RoomContainer.tsx
@@ -18,20 +18,15 @@ import { useGameStateStore } from '@/stores/websocket/useGameStateStore';
 import { useWebSocketStore } from '@/stores/websocket/useWebsocketStore';
 
 export default function GameRoomContainer({
-  userNickname,
   roomId,
   channelId,
 }: GameRoomServerProps) {
   const router = useRouter();
 
-  const { setNickname, nickname } = useNicknameStore();
+  const { nickname } = useNicknameStore();
   const { isConnected, updateSubscription, sendMessage } = useWebSocketStore();
   const { gameRoomInfo } = useGameInfoStore();
   const { gameState } = useGameStateStore();
-
-  useEffect(() => {
-    setNickname(userNickname);
-  }, [userNickname]);
 
   useEffect(() => {
     if (isConnected) {

--- a/src/components/room/RoomForm.tsx
+++ b/src/components/room/RoomForm.tsx
@@ -58,27 +58,22 @@ export default function RoomForm({
       initialData,
     });
   // useRoomApi에서 error 상태도 가져옴
-  const { loading, error, submitForm } = useRoomApi({
+  const { error, submitForm } = useRoomApi({
     mode,
     roomId,
     onSuccess,
   });
-  // 폼 제출 에러를 관리하기 위한 상태
   const [formSubmitError, setFormSubmitError] = useState<string | null>(null);
 
   const onSubmit = async (data: RoomFormValues) => {
-    // 폼 제출 시 에러 상태 초기화
     setFormSubmitError(null);
 
     try {
-      // submitForm 결과가 false인 경우 에러 처리
       const success = await submitForm(data);
       if (!success) {
         setFormSubmitError('방 생성/수정 중 오류가 발생했습니다.');
       }
-    } catch (err) {
-      // 예상치 못한 에러 처리
-      console.error('Unexpected error:', err);
+    } catch {
       setFormSubmitError('예상치 못한 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
@@ -405,11 +400,10 @@ export default function RoomForm({
             </button>
             <button
               type='submit'
-              disabled={loading}
               onClick={form.handleSubmit(onSubmit)}
               className='relative flex h-[50px] w-[50px] cursor-pointer items-center justify-center overflow-hidden rounded-full border-3 border-white bg-gradient-to-br from-purple-400 to-purple-900 text-sm font-bold text-white shadow-lg transition-all duration-300 ease-in-out hover:translate-y-[-2px] hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70'
             >
-              {loading ? '처리중' : mode === 'create' ? '생성' : '수정'}
+              {mode === 'create' ? '생성' : '수정'}
             </button>
           </div>
         </section>

--- a/src/components/room/utils/roomDataConverter.ts
+++ b/src/components/room/utils/roomDataConverter.ts
@@ -18,7 +18,7 @@ interface GameRoomInfo {
 /**
  * API 요청 데이터 인터페이스
  */
-interface ApiRequestData {
+export interface RoomApiRequestData {
   title: string;
   password: string;
   format?: string;
@@ -26,11 +26,10 @@ interface ApiRequestData {
   selectedYears: number[];
   maxGameRound?: number;
   maxPlayer?: number;
-  roomId?: string; // 방 수정하기 요청에서만 사용
-  channelId?: number; // 방 생성하기 요청에서만 사용
+  roomId?: string;
+  channelId?: number;
 }
 
-// 소켓 데이터를 폼 데이터로 변환 (GameInfoState -> FormValues)
 export function socketToFormData(
   gameRoomInfo: GameRoomInfo | null,
 ): Partial<RoomFormValues> | null {
@@ -54,7 +53,7 @@ export function socketToFormData(
 export function formToApiData(
   formData: RoomFormValues,
   roomId?: string,
-): ApiRequestData {
+): RoomApiRequestData {
   const password = formData.hasPassword ? formData.password : '';
   const currentChannelId = useChannelStore.getState().currentChannelId;
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,148 +2,61 @@ import { deleteCookie, setCookie } from 'cookies-next';
 import { useRouter } from 'next/router';
 import { toast } from 'sonner';
 
-import { useNicknameStore } from '@/stores/auth/useNicknameStore';
+import { guestLoginAPI, userLoginAPI, userSignupAPI } from '@/api/auth';
 
-interface UserCredentials {
+export interface UserCredentials {
   username: string;
   password: string;
 }
 
-interface GuestLoginResponse {
-  username: string;
-}
-
 export function useAuth() {
-  const { setNickname } = useNicknameStore();
   const router = useRouter();
 
   const guestLogin = async () => {
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/member/guest/login`,
-      );
-
-      if (!response.ok) {
-        toast.error('비회원 로그인에 실패했습니다.');
-        return null;
-      }
-
-      const { username }: GuestLoginResponse = await response.json();
-
-      setCookie('userNickname', username, {
-        maxAge: 60 * 60 * 24 * 7,
+    const { success, data, error } = await guestLoginAPI();
+    if (success) {
+      setCookie('accessToken', data.accessToken, {
+        maxAge: 60 * 60 * 24 * 30,
         path: '/',
       });
-      setNickname(username);
       toast.success('비회원으로 로그인했습니다.');
-
-      return { username };
-    } catch {
-      toast.error('비회원 로그인 중 오류가 발생했습니다.');
-      return null;
+    } else {
+      toast.error(error);
     }
   };
 
   const signUp = async ({ username, password }: UserCredentials) => {
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/member/user/signup`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ username, password }),
-        },
-      );
-
-      if (!response.ok) {
-        if (response.status === 409) {
-          toast.error('중복된 회원입니다.');
-        } else if (response.status === 500) {
-          toast.error(
-            '서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요.',
-          );
-        } else {
-          const { message } = (await response.json()) as { message: string };
-          toast.error(message);
-        }
-        return null;
-      }
-
-      let result = { success: true };
-
-      const text = await response.text();
-      if (text && text.trim()) {
-        result = JSON.parse(text);
-      }
-
-      toast.success('회원가입이 완료되었습니다.');
-      return result;
-    } catch {
-      toast.error('회원가입 중 오류가 발생했습니다.');
-      return null;
+    const { success, error } = await userSignupAPI({
+      username,
+      password,
+    });
+    if (success) {
+      toast.success('회원가입 성공', {
+        description: '환영합니다!',
+      });
+    } else {
+      toast.error(error);
     }
   };
 
   const userLogin = async ({ username, password }: UserCredentials) => {
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/member/user/login`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ username, password }),
-        },
-      );
-
-      if (!response.ok) {
-        if (response.status === 409) {
-          toast.error('로그인 정보가 올바르지 않습니다.');
-        } else {
-          toast.error(`로그인에 실패했습니다.`);
-        }
-        return null;
-      }
-
-      let userData;
-
-      try {
-        const text = await response.text();
-        if (text && text.trim()) {
-          userData = JSON.parse(text);
-        }
-      } catch {
-        userData = { username };
-      }
-
-      if (!userData || !userData.username) {
-        userData = { username };
-      }
-
-      setCookie('userNickname', userData.username, {
-        maxAge: 60 * 60 * 24 * 7,
+    const { success, data, error } = await userLoginAPI({ username, password });
+    if (success) {
+      setCookie('accessToken', data.accessToken, {
+        maxAge: 60 * 60 * 24 * 30,
         path: '/',
       });
-
-      setNickname(userData.username);
       toast.success('로그인 성공', {
         description: '환영합니다!',
       });
-
-      return userData;
-    } catch {
-      toast.error('로그인 중 오류가 발생했습니다.');
-      return null;
+    } else {
+      toast.error(error);
     }
   };
 
   const logout = () => {
     try {
       deleteCookie('userNickname', { path: '/' });
-      setNickname('');
       toast.success('로그아웃 되었습니다.');
       router.push('/');
     } catch {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router';
 import { toast } from 'sonner';
 
 import { guestLoginAPI, userLoginAPI, userSignupAPI } from '@/api/auth';
+import { userNicknameAPI } from '@/api/member';
+import { useNicknameStore } from '@/stores/auth/useNicknameStore';
 
 export interface UserCredentials {
   username: string;
@@ -20,6 +22,13 @@ export function useAuth() {
         path: '/',
       });
       toast.success('비회원으로 로그인했습니다.');
+
+      const { success: nicknameSuccess, data: nicknameData } =
+        await userNicknameAPI();
+
+      if (nicknameSuccess) {
+        useNicknameStore.getState().setNickname(nicknameData.username);
+      }
     } else {
       toast.error(error);
     }
@@ -49,6 +58,13 @@ export function useAuth() {
       toast.success('로그인 성공', {
         description: '환영합니다!',
       });
+
+      const { success: nicknameSuccess, data: nicknameData } =
+        await userNicknameAPI();
+
+      if (nicknameSuccess) {
+        useNicknameStore.getState().setNickname(nicknameData.username);
+      }
     } else {
       toast.error(error);
     }
@@ -56,9 +72,10 @@ export function useAuth() {
 
   const logout = () => {
     try {
-      deleteCookie('userNickname', { path: '/' });
+      deleteCookie('accessToken', { path: '/' });
       toast.success('로그아웃 되었습니다.');
       router.push('/');
+      useNicknameStore.getState().setNickname('');
     } catch {
       toast.error('로그아웃 중 오류가 발생했습니다.');
     }

--- a/src/hooks/useRoomApi.ts
+++ b/src/hooks/useRoomApi.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
+import { createRoomAPI, patchRoomAPI } from '@/api/room';
 import { formToApiData } from '@/components/room/utils/roomDataConverter';
-import { useNicknameStore } from '@/stores/auth/useNicknameStore';
 
 import type { RoomFormValues } from './useRoomForm';
 
@@ -12,14 +12,9 @@ interface UseRoomApiProps {
 }
 
 export function useRoomApi({ mode, roomId, onSuccess }: UseRoomApiProps) {
-  // 로딩 상태 관리
-  const [loading, setLoading] = useState(false);
-  // 에러 상태 관리
   const [error, setError] = useState<Error | null>(null);
-  const { nickname } = useNicknameStore();
 
   const submitForm = async (data: RoomFormValues) => {
-    setLoading(true);
     setError(null);
 
     const requestData = formToApiData(
@@ -27,62 +22,36 @@ export function useRoomApi({ mode, roomId, onSuccess }: UseRoomApiProps) {
       mode === 'edit' ? roomId : undefined,
     );
 
-    const headers = {
-      Authorization: nickname,
-      'Content-Type': 'application/json',
-    };
-
-    try {
-      let success = false;
-
-      try {
-        if (mode === 'create') {
-          const response = await fetch(
-            `${process.env.NEXT_PUBLIC_BASE_URL}/room`,
-            {
-              method: 'POST',
-              headers,
-              body: JSON.stringify(requestData),
-            },
-          );
-
-          if (!response.ok) {
-            setError(new Error('방 생성에 실패했습니다.'));
-          } else {
-            const responseData = await response.json();
-            onSuccess(data, responseData.roomId);
-            success = true;
-          }
-        } else if (mode === 'edit' && roomId) {
-          const response = await fetch(
-            `${process.env.NEXT_PUBLIC_BASE_URL}/room`,
-            {
-              method: 'PATCH',
-              headers,
-              body: JSON.stringify(requestData),
-            },
-          );
-
-          if (!response.ok) {
-            setError(new Error('방 수정에 실패했습니다.'));
-          } else {
-            onSuccess(data, roomId);
-            success = true;
-          }
-        }
-      } catch {
-        setError(new Error('요청 처리 중 오류가 발생했습니다.'));
+    if (mode === 'edit') {
+      const {
+        data: responseData,
+        success,
+        error,
+      } = await patchRoomAPI(requestData);
+      if (success) {
+        onSuccess(data, responseData.roomId);
+      } else {
+        setError(new Error(error));
       }
 
       return success;
-    } finally {
-      setLoading(false);
+    }
+
+    if (mode === 'create') {
+      const {
+        data: responseData,
+        success,
+        error,
+      } = await createRoomAPI(requestData);
+      if (success) {
+        onSuccess(data, responseData.roomId);
+      } else {
+        setError(new Error(error));
+      }
+
+      return success;
     }
   };
 
-  return {
-    loading,
-    error,
-    submitForm,
-  };
+  return { error, submitForm };
 }

--- a/src/pages/game/lobby/[channelId].tsx
+++ b/src/pages/game/lobby/[channelId].tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import axios from 'axios';
-import { getCookie } from 'cookies-next';
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
 import { useRouter } from 'next/router';
+import { toast } from 'sonner';
 
+import { ApiContext } from '@/api/core';
+import { Member, getChannelUsersAPI, userNicknameAPI } from '@/api/member';
+import { getRoomsAPI } from '@/api/room';
 import SEO from '@/components/SEO';
 import BackgroundMusic from '@/components/common/BackgroundMusic';
 import ChannelMemberList from '@/components/lobby/ChannelMemberList';
@@ -16,8 +18,6 @@ import RoomSearchDialog from '@/components/lobby/RoomSearchDialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useNicknameStore } from '@/stores/auth/useNicknameStore';
 import { useChannelStore } from '@/stores/lobby/useChannelStore';
-
-const API_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 const SSE_EVENTS = {
   CONNECT: 'CONNECT',
@@ -33,6 +33,8 @@ const ACTION_TYPES = {
   UPDATED: 'UPDATED',
   FINISHED: 'FINISHED',
 } as const;
+
+const PAGE_SIZE = 6;
 
 export type Room = {
   id: string;
@@ -68,22 +70,15 @@ export const getServerSideProps: GetServerSideProps = async ({
   res,
   params,
 }) => {
-  const userNickname = (await getCookie('userNickname', { req, res })) || '';
   const { channelId } = params as { channelId: string };
+  const ctx: ApiContext = {
+    req: req as NextApiRequest,
+    res: res as NextApiResponse,
+  };
 
-  // 유효하지 않은 채널 ID 검증 (숫자가 아니거나 범위를 벗어난 경우)
-  if (
-    !channelId ||
-    !/^\d+$/.test(channelId) || // 숫자만 허용
-    parseInt(channelId) <= 0 || // 양수만 허용
-    parseInt(channelId) > 6
-  ) {
-    return {
-      notFound: true,
-    };
-  }
+  const { success, data } = await userNicknameAPI(ctx);
 
-  if (!userNickname) {
+  if (!success || !data) {
     return {
       redirect: {
         destination: '/',
@@ -92,9 +87,18 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
+  if (
+    !channelId ||
+    !/^\d+$/.test(channelId) ||
+    parseInt(channelId) <= 0 ||
+    parseInt(channelId) > 6
+  ) {
+    return { notFound: true };
+  }
+
   return {
     props: {
-      userNickname,
+      userNickname: data.username,
       channelId,
     },
   };
@@ -116,9 +120,7 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
   const [sseConnected, setSseConnected] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [totalPages, setTotalPages] = useState<number>(1);
-  const pageSize = 6;
 
-  // 채널 멤버 관련 상태
   const [members, setMembers] = useState<ChannelMember[]>([]);
   const [isMembersLoading, setIsMembersLoading] = useState<boolean>(true);
 
@@ -156,126 +158,105 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
     }
   }, [router.query, currentPage]);
 
-  // 컴포넌트 마운트 시에만 로딩 상태 설정
   useEffect(() => {
     setIsLoading(true);
 
     const fetchInitialData = async () => {
-      try {
-        const response = await axios.get(`${API_URL}/room`, {
-          params: {
-            channelId: channelId,
-            page: 0,
-            size: pageSize,
-          },
-        });
+      const { data, success } = await getRoomsAPI(channelId, 0);
 
-        const data = response.data;
-        setRooms(data.content || []);
-        setCurrentPage(data.number || 0);
-        setTotalPages(data.totalPages || 1);
+      if (!success || !data) {
         setIsLoading(false);
-      } catch (error) {
-        console.error('초기 데이터 로딩 오류:', error);
-        setIsLoading(false);
+        return;
       }
+
+      setRooms(data.content || []);
+      setCurrentPage(data.number || 0);
+      setTotalPages(data.totalPages || 1);
+      setIsLoading(false);
     };
 
     fetchInitialData();
-
-    // 이 useEffect는 컴포넌트가 마운트될 때 한 번만 실행됩니다
   }, []);
 
-  // 채널 멤버 목록 가져오기
   useEffect(() => {
     const fetchChannelMembers = async () => {
-      try {
-        setIsMembersLoading(true);
-        const response = await axios.get(`${API_URL}/member/${channelId}`);
-        let membersData = response.data || [];
+      setIsMembersLoading(true);
 
-        // 내 정보가 목록에 없는 경우 추가
-        const isCurrentUserInList = membersData.some(
-          (member: ChannelMember) => member.username === userNickname,
-        );
+      const { success, data } = await getChannelUsersAPI(channelId);
 
-        if (!isCurrentUserInList) {
-          // 기본적으로 내 정보를 로비에 있는 상태로 추가
-          membersData = [
-            ...membersData,
-            {
-              username: userNickname,
-              memberType: 'GUEST',
-              inLobby: true,
-              roomStatus: null,
-            },
-          ];
-        }
+      const membersData: ChannelMember[] = [];
 
-        setMembers(membersData);
-        setIsMembersLoading(false);
-      } catch (error) {
-        console.error('채널 멤버 목록 가져오기 오류:', error);
-        setIsMembersLoading(false);
+      if (success) {
+        data.users.forEach((user: Member) => {
+          membersData.push({
+            username: user.username,
+            memberType: user.memberType,
+            inLobby: user.inLobby,
+            roomStatus: user.roomStatus,
+          });
+        });
       }
+
+      const isCurrentUserInList = membersData.some(
+        (member: ChannelMember) => member.username === userNickname,
+      );
+
+      if (!isCurrentUserInList) {
+        membersData.push({
+          username: userNickname,
+          memberType: 'GUEST',
+          inLobby: true,
+          roomStatus: null,
+        });
+      }
+
+      setMembers(membersData);
+      setIsMembersLoading(false);
     };
 
     fetchChannelMembers();
   }, [channelId, userNickname]);
 
-  // 페이지 전환 처리 함수
   const handlePageChange = async (newPage: number) => {
-    try {
-      await router.push(
-        {
-          pathname: router.pathname,
-          query: {
-            ...router.query,
-            page: newPage,
-          },
-        },
-        undefined,
-        { shallow: true },
-      );
-
-      const response = await axios.get(`${API_URL}/room`, {
-        params: {
-          channelId: channelId,
+    router.push(
+      {
+        pathname: router.pathname,
+        query: {
+          ...router.query,
           page: newPage,
-          size: pageSize,
         },
-      });
+      },
+      undefined,
+      { shallow: true },
+    );
 
-      const data = response.data;
-      setRooms(data.content || []);
-      setCurrentPage(data.pageable?.pageNumber || newPage);
-      setTotalPages(data.totalPages || 1);
-    } catch (error) {
-      console.error('방 목록 가져오기 오류:', error);
+    const { data, success } = await getRoomsAPI(channelId, newPage);
+
+    if (!success || !data) {
+      setIsLoading(false);
+      return;
     }
+
+    setRooms(data.content || []);
+    setCurrentPage(data.number || newPage);
+    setTotalPages(data.totalPages || 1);
   };
 
   const handleEventData = useCallback(
     (event: MessageEvent, eventName: string) => {
-      try {
-        let data;
+      let data;
 
-        if (eventName === SSE_EVENTS.CONNECT) {
-          data = event.data;
-          return data;
-        }
-
-        data = JSON.parse(event.data);
+      if (eventName === SSE_EVENTS.CONNECT) {
+        data = event.data;
         return data;
-      } catch (error) {
-        console.error(`${eventName} 이벤트 처리 오류:`, error);
-        return null;
       }
+
+      data = JSON.parse(event.data);
+      return data;
     },
     [],
   );
 
-  // SSE 연결 및 이벤트 처리
   useEffect(() => {
     let eventSource: EventSource | null = null;
 
@@ -299,7 +280,6 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
         setSseConnected(true);
       });
 
-      // ROOM_UPDATED 이벤트 처리
       eventSource.addEventListener(SSE_EVENTS.ROOM_UPDATED, event => {
         const data = handleEventData(event, SSE_EVENTS.ROOM_UPDATED);
 
@@ -340,100 +320,76 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
 
           // 페이지에 대한 GET 요청을 보내 새로운 목록을 받아옴
           const fetchUpdatedRooms = async () => {
-            try {
-              const response = await axios.get(`${API_URL}/room`, {
-                params: {
-                  channelId: channelId,
-                  page: pageNow,
-                  size: pageSize,
-                },
-              });
+            const { data, success } = await getRoomsAPI(channelId, pageNow);
 
-              const newRoomsData = response.data.content || [];
+            if (!success || !data) {
+              toast.error('방 목록 가져오기 오류');
+              setIsLoading(false);
+              return;
+            }
 
-              setRooms(currentRooms => {
-                // 방 목록 업데이트 로직
-                const finishedRoomIndex = currentRooms.findIndex(
-                  (room: Room) => room.id === roomId,
+            const newRoomsData = data.content || [];
+
+            setRooms(currentRooms => {
+              const finishedRoomIndex = currentRooms.findIndex(
+                (room: Room) => room.id === roomId,
+              );
+
+              if (finishedRoomIndex === -1) {
+                return currentRooms;
+              }
+
+              const remainingRooms = currentRooms.filter(
+                (room: Room) => room.id !== roomId,
+              );
+
+              if (newRoomsData.length === currentRooms.length) {
+                const newRoom = newRoomsData.find(
+                  (room: Room) =>
+                    !currentRooms.some(
+                      (existingRoom: Room) => existingRoom.id === room.id,
+                    ),
                 );
 
-                if (finishedRoomIndex === -1) {
-                  return currentRooms; // FINISHED 방이 이미 처리되었거나 없는 경우
+                if (newRoom) {
+                  const result = [...remainingRooms];
+                  result.splice(finishedRoomIndex, 0, newRoom);
+                  return result;
                 }
 
-                // 기존 방 목록에서 FINISHED 방을 제외한 나머지 방들
+                return currentRooms;
+              } else if (newRoomsData.length < currentRooms.length) {
+                return remainingRooms;
+              } else {
                 const remainingRooms = currentRooms.filter(
                   (room: Room) => room.id !== roomId,
                 );
 
-                // 결과 목록의 개수가 기존과 동일한 경우
-                if (newRoomsData.length === currentRooms.length) {
-                  // 기존 목록에 없는 새로운 방 찾기
-                  const newRoom = newRoomsData.find(
-                    (room: Room) =>
-                      !currentRooms.some(
-                        (existingRoom: Room) => existingRoom.id === room.id,
-                      ),
-                  );
+                const newRooms = newRoomsData.filter(
+                  (room: Room) =>
+                    !currentRooms.some(
+                      (existingRoom: Room) => existingRoom.id === room.id,
+                    ),
+                );
 
-                  if (newRoom) {
-                    // FINISHED된 방 위치에 새로운 방으로 대체
-                    const result = [...remainingRooms];
-                    result.splice(finishedRoomIndex, 0, newRoom);
-                    return result;
+                const result = [...remainingRooms];
+                if (newRooms.length > 0) {
+                  result.splice(finishedRoomIndex, 0, newRooms[0]);
+
+                  if (newRooms.length > 1) {
+                    result.push(...newRooms.slice(1));
                   }
-
-                  // 새로운 방을 찾지 못한 경우 기존 목록 유지 (FINISHED 방은 disabled 상태로)
-                  return currentRooms;
                 }
-                // 결과 목록의 개수가 기존보다 적은 경우
-                else if (newRoomsData.length < currentRooms.length) {
-                  // FINISHED된 방을 제외
-                  return remainingRooms;
-                }
-                // 결과 목록의 개수가 기존보다 많은 경우
-                else {
-                  // 1. FINISHED 방을 제외한 기존 방 목록 구성
-                  const remainingRooms = currentRooms.filter(
-                    (room: Room) => room.id !== roomId,
-                  );
 
-                  // 2. 기존에 없던 새로운 방들 찾기
-                  const newRooms = newRoomsData.filter(
-                    (room: Room) =>
-                      !currentRooms.some(
-                        (existingRoom: Room) => existingRoom.id === room.id,
-                      ),
-                  );
-
-                  // 3. FINISHED 방 위치에 새로운 방 중 하나를 배치
-                  const result = [...remainingRooms];
-                  if (newRooms.length > 0) {
-                    result.splice(finishedRoomIndex, 0, newRooms[0]);
-
-                    // 4. 나머지 새로운 방들은 배열 뒤에 추가
-                    if (newRooms.length > 1) {
-                      result.push(...newRooms.slice(1));
-                    }
-                  }
-
-                  // 5. 페이지 크기에 맞게 목록 조정
-                  return result.slice(0, pageSize);
-                }
-              });
-            } catch (error) {
-              console.error(
-                'FINISHED 상태 방 처리 중 방 목록 가져오기 오류:',
-                error,
-              );
-            }
+                return result.slice(0, PAGE_SIZE);
+              }
+            });
           };
 
           fetchUpdatedRooms();
           return;
         }
 
-        // CREATED 또는 UPDATED 상태인 방 처리 (room 객체가 있는 경우)
         if (
           (data.actionType === ACTION_TYPES.CREATED ||
             data.actionType === ACTION_TYPES.UPDATED) &&
@@ -441,9 +397,7 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
         ) {
           const updatedRoom = data.room;
 
-          // CREATED 액션 처리 - 주로 첫 페이지에 새 방을 추가
           if (data.actionType === ACTION_TYPES.CREATED) {
-            // 사용자가 첫페이지에 있을 경우에만 새 방 추가
             if (pageNow === 0) {
               setRooms(currentRooms => {
                 const roomIndex = currentRooms.findIndex(
@@ -451,15 +405,13 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
                 );
 
                 if (roomIndex !== -1) {
-                  // 이미 존재하는 방이면 업데이트
                   const newRooms = [...currentRooms];
                   newRooms[roomIndex] = updatedRoom;
                   return newRooms;
                 } else {
-                  // 새 방이면 맨 앞에 추가
                   const newRooms = [updatedRoom, ...currentRooms];
-                  if (newRooms.length > pageSize) {
-                    return newRooms.slice(0, pageSize);
+                  if (newRooms.length > PAGE_SIZE) {
+                    return newRooms.slice(0, PAGE_SIZE);
                   }
                   return newRooms;
                 }
@@ -601,7 +553,7 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
         eventSource.close();
       }
     };
-  }, [handleEventData, pageSize, SSE_ENDPOINT, channelId]);
+  }, [handleEventData, PAGE_SIZE, SSE_ENDPOINT, channelId]);
 
   // SSE 연결 끊겼을 때 처리
   useEffect(() => {
@@ -614,7 +566,7 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
   // 페이지 언로드 시 연결 해제 처리
   useEffect(() => {
     const handleUnload = () => {
-      navigator.sendBeacon(`${API_URL}/sse/disconnect`);
+      navigator.sendBeacon(`${process.env.NEXT_PUBLIC_SSE_URL}/disconnect`);
     };
 
     window.addEventListener('beforeunload', handleUnload);

--- a/src/pages/game/lobby/[channelId].tsx
+++ b/src/pages/game/lobby/[channelId].tsx
@@ -187,7 +187,7 @@ const LobbyPage = ({ userNickname, channelId }: LobbyServerProps) => {
       const membersData: ChannelMember[] = [];
 
       if (success) {
-        data.users.forEach((user: Member) => {
+        data.userList.forEach((user: Member) => {
           membersData.push({
             username: user.username,
             memberType: user.memberType,

--- a/src/pages/game/room/[channelId]/[roomId].tsx
+++ b/src/pages/game/room/[channelId]/[roomId].tsx
@@ -1,6 +1,7 @@
-import { getCookie } from 'cookies-next';
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
 
+import { ApiContext } from '@/api/core';
+import { userNicknameAPI } from '@/api/member';
 import SEO from '@/components/SEO';
 import GameRoomContainer from '@/components/room/RoomContainer';
 
@@ -9,10 +10,18 @@ export const getServerSideProps: GetServerSideProps = async ({
   res,
   params,
 }) => {
-  const userNickname = (await getCookie('userNickname', { req, res })) || '';
+  const ctx: ApiContext = {
+    req: req as NextApiRequest,
+    res: res as NextApiResponse,
+  };
+
+  const result = await userNicknameAPI(ctx);
+
+  const userNickname = result.data?.username || '';
+
   const { roomId, channelId } = params as { roomId: string; channelId: string };
 
-  if (!userNickname) {
+  if (!result.data?.username) {
     return {
       redirect: {
         destination: '/',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 
-import { getCookie } from 'cookies-next';
 import { motion } from 'framer-motion';
 import { ThumbsUp } from 'lucide-react';
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
 
+import { ApiContext } from '@/api/core';
+import { userNicknameAPI } from '@/api/member';
 import SEO from '@/components/SEO';
 import AccountFormDialog from '@/components/auth/AccountFormDialog';
 import BackgroundMusic from '@/components/common/BackgroundMusic';
@@ -15,11 +16,18 @@ import { useAuth } from '@/hooks/useAuth';
 import { useNicknameStore } from '@/stores/auth/useNicknameStore';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-  const userNickname = (await getCookie('userNickname', { req, res })) || '';
+  const ctx: ApiContext = {
+    req: req as NextApiRequest,
+    res: res as NextApiResponse,
+  };
+
+  const result = await userNicknameAPI(ctx);
+
+  console.log('result:', result);
 
   return {
     props: {
-      userNickname,
+      userNickname: result.data?.username || null,
     },
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,8 +23,6 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 
   const result = await userNicknameAPI(ctx);
 
-  console.log('result:', result);
-
   return {
     props: {
       userNickname: result.data?.username || null,

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -1,9 +1,10 @@
 import { Client, StompSubscription } from '@stomp/stompjs';
+import { getCookie } from 'cookies-next';
 import { create } from 'zustand';
 
+import { COOKIE_NAME } from '@/api/core';
 import { WebSocketState } from '@/types/websocket';
 
-import { useNicknameStore } from '../auth/useNicknameStore';
 import { useSoundEventStore } from '../useSoundEventStore';
 import { useGameBubbleStore } from './useGameBubbleStore';
 import { useGameChatStore } from './useGameChatStore';
@@ -29,7 +30,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
       webSocketFactory: () =>
         new WebSocket(`${process.env.NEXT_PUBLIC_WEBSOCKET_URL}`),
       connectHeaders: {
-        Authorization: useNicknameStore.getState().nickname,
+        Authorization: getCookie(COOKIE_NAME) as string,
       },
       reconnectDelay: 5000,
       heartbeatIncoming: 4000,
@@ -90,7 +91,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           usePublicChatStore.getState().setPublicChattings(response);
         },
         {
-          Authorization: useNicknameStore.getState().nickname,
+          Authorization: getCookie(COOKIE_NAME) as string,
         },
       );
     }
@@ -119,7 +120,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           }
         },
         {
-          Authorization: useNicknameStore.getState().nickname,
+          Authorization: getCookie(COOKIE_NAME) as string,
         },
       );
 
@@ -135,8 +136,6 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
               message: `곧 다음 라운드가 시작됩니다. `,
             });
 
-            // url, round, mode 설정 및 힌트는 null 처리 + songUrl2는 듀얼 모드에서만
-            // 임의로 songUrl2 설정해봄
             roundInfo.setRoundInfo(response);
             roundHint.updateGameHint(null);
             useGameRoundResultStore.getState().setGameRoundResult(null);
@@ -276,7 +275,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           }
         },
         {
-          Authorization: useNicknameStore.getState().nickname,
+          Authorization: getCookie(COOKIE_NAME) as string,
         },
       );
     }

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -306,6 +306,12 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
       return;
     }
 
-    client.publish({ destination, body: JSON.stringify(payload) });
+    client.publish({
+      destination,
+      body: JSON.stringify(payload),
+      headers: {
+        Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
+      },
+    });
   },
 }));

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -84,11 +84,27 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
     const newSubscriptions: Record<string, StompSubscription> = {};
 
     if (subscriptionType === 'channel') {
+      const gameStateStore = useGameStateStore.getState();
+
       newSubscriptions['channel'] = client.subscribe(
         `/topic/channel/${channelId}`,
         message => {
           const { response } = JSON.parse(message.body);
           usePublicChatStore.getState().setPublicChattings(response);
+        },
+        {
+          Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
+        },
+      );
+
+      newSubscriptions['messageQueue'] = client.subscribe(
+        `/user/queue/system`,
+        message => {
+          const { type } = JSON.parse(message.body);
+
+          if (type === 'refuseEnter') {
+            gameStateStore.setGameState('REFUSED');
+          }
         },
         {
           Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -1,5 +1,6 @@
 import { Client, StompSubscription } from '@stomp/stompjs';
 import { getCookie } from 'cookies-next';
+import { toast } from 'sonner';
 import { create } from 'zustand';
 
 import { COOKIE_NAME } from '@/api/core';
@@ -100,10 +101,11 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
       newSubscriptions['messageQueue'] = client.subscribe(
         `/user/queue/system`,
         message => {
-          const { type } = JSON.parse(message.body);
+          const { type, response } = JSON.parse(message.body);
 
           if (type === 'refuseEnter') {
             gameStateStore.setGameState('REFUSED');
+            toast.error(response.message || '알 수 없는 문제가 발생했습니다.');
           }
         },
         {
@@ -129,10 +131,11 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
       newSubscriptions['messageQueue'] = client.subscribe(
         `/user/queue/system`,
         message => {
-          const { type } = JSON.parse(message.body);
+          const { type, response } = JSON.parse(message.body);
 
           if (type === 'refuseEnter') {
             gameStateStore.setGameState('REFUSED');
+            toast.error(response.message || '알 수 없는 문제가 발생했습니다.');
           }
         },
         {

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -30,7 +30,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
       webSocketFactory: () =>
         new WebSocket(`${process.env.NEXT_PUBLIC_WEBSOCKET_URL}`),
       connectHeaders: {
-        Authorization: getCookie(COOKIE_NAME) as string,
+        Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
       },
       reconnectDelay: 5000,
       heartbeatIncoming: 4000,
@@ -91,7 +91,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           usePublicChatStore.getState().setPublicChattings(response);
         },
         {
-          Authorization: getCookie(COOKIE_NAME) as string,
+          Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
         },
       );
     }
@@ -120,7 +120,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           }
         },
         {
-          Authorization: getCookie(COOKIE_NAME) as string,
+          Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
         },
       );
 
@@ -275,7 +275,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
           }
         },
         {
-          Authorization: getCookie(COOKIE_NAME) as string,
+          Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,
         },
       );
     }


### PR DESCRIPTION
1. core에서 정상응답과 4xx응답일 때 response 타입을 분리해서 응답하는 방식으로 정의합니다. 

```ts

type ApiSuccess<T> = {
  success: true;
  data: T;
  error: null;
};

type ApiFail = {
  success: false;
  data: null;
  error: string;
};

export type ApiResponse<T> = ApiSuccess<T> | ApiFail;

// 이게 ApiFail 타입
  if (!res.ok) {
    return {
      data: null,
      success: false,
      error: data.message || res.statusText,
    };
  }

// 이게 ApiSuccess
  return {
    data: data as T,
    success: true,
    error: null,
  };
  
  ```
  
  이걸 두가지로 나눈 이유는, success가 true일 때와 false일 때 상황에 따라 error와 data를 처리해야하는데, 단순 하나의 타입으로 처리해버리면 
  
  data가 `null | T ` 이기 때문에 타입추론이 안됩니다. 그래서 객체 자체의 타입을 유니온으로 정의해야 success에 따라 실제 코드환경에서 분기처리가 잘 됩니다. 


```js

  const {
      data,
      error: apiResponseError,
      success,
    } = await enterRoomAPI(room.id, password);

    if (!success) {
      toast.error(apiResponseError);
    }
    
 ```