### PR TITLE
fix: zustand state 호출 시 selector 적용

### DIFF
--- a/src/components/game-room/ChatBox.tsx
+++ b/src/components/game-room/ChatBox.tsx
@@ -13,11 +13,11 @@ interface ChatBoxProps {
 }
 
 const ChatBox = ({ currentUserId, roomId, channelId }: ChatBoxProps) => {
+  const gameChattings = useGameChatStore(state => state.gameChattings);
+  const sendMessage = useWebSocketStore(state => state.sendMessage);
+
   const [inputValue, setInputValue] = useState('');
   const chatContainerRef = useRef<HTMLDivElement>(null);
-
-  const { gameChattings } = useGameChatStore();
-  const { sendMessage } = useWebSocketStore();
 
   useEffect(() => {
     if (chatContainerRef.current) {

--- a/src/components/game-room/ScoreChatBox.tsx
+++ b/src/components/game-room/ScoreChatBox.tsx
@@ -16,11 +16,11 @@ const ScoreChatBox = ({
   roomId,
   channelId,
 }: ScoreChatBoxProps) => {
+  const gameChattings = useGameChatStore(state => state.gameChattings);
+  const sendMessage = useWebSocketStore(state => state.sendMessage);
+
   const [inputValue, setInputValue] = useState('');
   const chatContainerRef = useRef<HTMLDivElement>(null);
-
-  const { gameChattings } = useGameChatStore();
-  const { sendMessage } = useWebSocketStore();
 
   useEffect(() => {
     if (chatContainerRef.current) {

--- a/src/components/game-room/boardMap/GameBoard.tsx
+++ b/src/components/game-room/boardMap/GameBoard.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { useShallow } from 'zustand/shallow';
+
 import { useBoardAnimation } from '@/hooks/useBoardAnimation';
 import { useBoardLayoutSize } from '@/hooks/useBoardLayoutSize';
 import { useWindowSize } from '@/hooks/useWindowSize';
@@ -44,11 +46,19 @@ const ANIMATION_CONFIG = {
 };
 
 const GameBoard = () => {
-  const { scores } = useScoreStore();
-  const { targetUser, triggerUser, eventType } = useGameBubbleStore();
-  const { participantInfo } = useParticipantInfoStore();
-  const { setSoundEvent } = useSoundEventStore();
-  const { isActiveDice } = useGameDiceStore();
+  const scores = useScoreStore(state => state.scores);
+  const { targetUser, triggerUser, eventType } = useGameBubbleStore(
+    useShallow(state => ({
+      targetUser: state.targetUser,
+      triggerUser: state.triggerUser,
+      eventType: state.eventType,
+    })),
+  );
+  const participantInfo = useParticipantInfoStore(
+    state => state.participantInfo,
+  );
+  const setSoundEvent = useSoundEventStore(state => state.setSoundEvent);
+  const isActiveDice = useGameDiceStore(state => state.isActiveDice);
 
   const { windowSize } = useWindowSize();
   const { layoutSize } = useBoardLayoutSize(windowSize, BOARD_CONFIG);

--- a/src/components/game-room/boardMap/bubble/BubbleContent.tsx
+++ b/src/components/game-room/boardMap/bubble/BubbleContent.tsx
@@ -16,11 +16,13 @@ interface BubbleContentProps {
   isActive: boolean;
 }
 const BubbleContent = ({ isActive }: BubbleContentProps) => {
+  const diceTotalmovement = useGameDiceStore(state => state.diceTotalmovement);
+  const setSoundEvent = useSoundEventStore(state => state.setSoundEvent);
+
   const [currentImage, setCurrentImage] = useState(1);
   const [isAnimating, setIsAnimating] = useState(false);
-  const { diceTotalmovement } = useGameDiceStore();
+
   const animationRef = useRef<NodeJS.Timeout | null>(null);
-  const { setSoundEvent } = useSoundEventStore();
 
   useEffect(() => {
     if (isActive && !isAnimating) {

--- a/src/components/game-room/boardMap/bubble/index.tsx
+++ b/src/components/game-room/boardMap/bubble/index.tsx
@@ -11,7 +11,7 @@ interface BubbleProps {
 }
 
 const Bubble = ({ isActiveDice, character, charWidth }: BubbleProps) => {
-  const { diceUsername } = useGameDiceStore();
+  const diceUsername = useGameDiceStore(state => state.diceUsername);
 
   const isLeftSide = BUBBLE_RIGHT_MAP[character.position] || false;
   const bubbleSize = charWidth * 2;

--- a/src/components/game-room/boardMap/index.tsx
+++ b/src/components/game-room/boardMap/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { useShallow } from 'zustand/shallow';
+
 import { BOARD_MAP_SOUNDS } from '@/constants/config/soundConfig';
 import useSound from '@/hooks/useSound';
 import { cn } from '@/lib/utils';
@@ -10,8 +12,13 @@ import GamePlaySection from '../gamePlaySection';
 import GameBoard from './GameBoard';
 
 const BoardMap = () => {
-  const { gameState } = useGameStateStore();
-  const { soundEvent, setSoundEvent } = useSoundEventStore();
+  const gameState = useGameStateStore(state => state.gameState);
+  const { soundEvent, setSoundEvent } = useSoundEventStore(
+    useShallow(state => ({
+      soundEvent: state.soundEvent,
+      setSoundEvent: state.setSoundEvent,
+    })),
+  );
 
   const { play, stop } = useSound(BOARD_MAP_SOUNDS);
 

--- a/src/components/game-room/boardMap/index.tsx
+++ b/src/components/game-room/boardMap/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { BOARD_MAP_SOUNDS } from '@/constants/config/soundConfig';
 import useSound from '@/hooks/useSound';
 import { cn } from '@/lib/utils';
 import { useSoundEventStore } from '@/stores/useSoundEventStore';
@@ -12,19 +13,7 @@ const BoardMap = () => {
   const { gameState } = useGameStateStore();
   const { soundEvent, setSoundEvent } = useSoundEventStore();
 
-  const { play, stop } = useSound([
-    { key: 'EVENT_CARD', url: '/audio/playsound/event-card.mp3' },
-    { key: 'JUMP', url: '/audio/playsound/jump.mp3' },
-    { key: 'ROULETTE', url: '/audio/playsound/roulette.mp3' },
-    { key: 'ROULETTE_RESULT', url: '/audio/playsound/roulette-result.mp3' },
-    { key: 'ROULETTE_123', url: '/audio/playsound/roulette-123.mp3' },
-    {
-      key: 'ROULETTE_123_RESULT',
-      url: '/audio/playsound/roulette-123-result.mp3',
-    },
-    { key: 'CORRECT', url: '/audio/playsound/correct.mp3' },
-    { key: 'WINNER', url: '/audio/playsound/winner.mp3' },
-  ]);
+  const { play, stop } = useSound(BOARD_MAP_SOUNDS);
 
   useEffect(() => {
     if (soundEvent) play(soundEvent);

--- a/src/components/game-room/gamePlaySection/RotatingLP.tsx
+++ b/src/components/game-room/gamePlaySection/RotatingLP.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { useGameStateStore } from '@/stores/websocket/useGameStateStore';
 
 const RotatingLP = () => {
-  const { gameState } = useGameStateStore();
+  const gameState = useGameStateStore(state => state.gameState);
   const controls = useAnimation();
 
   useEffect(() => {

--- a/src/components/game-room/gamePlaySection/RoundInfomation.tsx
+++ b/src/components/game-room/gamePlaySection/RoundInfomation.tsx
@@ -6,7 +6,7 @@ import RoundRolling from '../gameScreen/RoundRolling';
 import YoutubePlayer from '../gameScreen/YoutubePlayer';
 
 const RoundInformation = () => {
-  const { gameState } = useGameStateStore();
+  const gameState = useGameStateStore(state => state.gameState);
 
   return (
     <div className='flex h-[300px] min-w-[60%] flex-col items-center justify-center rounded-2xl bg-black/80 p-4'>

--- a/src/components/game-room/gamePlaySection/index.tsx
+++ b/src/components/game-room/gamePlaySection/index.tsx
@@ -16,11 +16,13 @@ import RoundInformation from './RoundInfomation';
 import SpeechBubble from './SpeechBubble';
 
 const GamePlaySection = () => {
-  const { participantInfo } = useParticipantInfoStore();
-  const { gameRoomInfo } = useGameInfoStore();
-  const { gameChattings } = useGameChatStore();
-  const { gameState } = useGameStateStore();
-  const { winner } = useGameWinnerStore();
+  const participantInfo = useParticipantInfoStore(
+    state => state.participantInfo,
+  );
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const gameChattings = useGameChatStore(state => state.gameChattings);
+  const gameState = useGameStateStore(state => state.gameState);
+  const winner = useGameWinnerStore(state => state.winner);
 
   const [chattingMap, setChattingMap] = useState<
     Record<string, { message: string; timestamp: number }>

--- a/src/components/game-room/gameRoomInfo/EditRoomButton.tsx
+++ b/src/components/game-room/gameRoomInfo/EditRoomButton.tsx
@@ -28,9 +28,9 @@ export default function EditRoomButton({
     }
   }, [router.isReady, router.asPath]);
 
-  const { gameRoomInfo } = useGameInfoStore();
-  const { hostNickname } = useParticipantInfoStore();
-  const { nickname } = useNicknameStore();
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const hostNickname = useParticipantInfoStore(state => state.hostNickname);
+  const nickname = useNicknameStore(state => state.nickname);
 
   // 방장인지 확인
   const isRoomOwner = (hostNickname && hostNickname === nickname) || false;

--- a/src/components/game-room/gameRoomInfo/RoomInfo.tsx
+++ b/src/components/game-room/gameRoomInfo/RoomInfo.tsx
@@ -25,8 +25,10 @@ const yearMap: SelectedYearType[] = [
 ];
 
 const GameRoomInfo = () => {
-  const { gameRoomInfo } = useGameInfoStore();
-  const { participantInfo } = useParticipantInfoStore();
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const participantInfo = useParticipantInfoStore(
+    state => state.participantInfo,
+  );
 
   if (!gameRoomInfo) return null;
 

--- a/src/components/game-room/gameScreen/GameMusicPlayer.tsx
+++ b/src/components/game-room/gameScreen/GameMusicPlayer.tsx
@@ -10,7 +10,8 @@ interface MusicPlayerProps {
 }
 
 const GameMusicPlayer = ({ gameState }: MusicPlayerProps) => {
-  const { roundInfo } = useGameRoundInfoStore();
+  const roundInfo = useGameRoundInfoStore(state => state.roundInfo);
+
   if (!roundInfo) return null;
   const { round: currentRound, mode } = roundInfo;
   const isDualMode = mode === 'DUAL';

--- a/src/components/game-room/gameScreen/GameResultContent.tsx
+++ b/src/components/game-room/gameScreen/GameResultContent.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { useGameWinnerStore } from '@/stores/websocket/useGameWinnerStore';
 
 const GameResultContent = () => {
-  const { winner } = useGameWinnerStore();
+  const winner = useGameWinnerStore(state => state.winner);
 
   return (
     <div className='flex w-full flex-col items-center justify-center py-6'>

--- a/src/components/game-room/gameScreen/RoundPlayContent.tsx
+++ b/src/components/game-room/gameScreen/RoundPlayContent.tsx
@@ -13,8 +13,8 @@ export interface GameHint {
 }
 
 const RoundPlayContent = () => {
-  const { roundHint } = useRoundHintStore();
-  const { roundInfo } = useGameRoundInfoStore();
+  const roundHint = useRoundHintStore(state => state.roundHint);
+  const roundInfo = useGameRoundInfoStore(state => state.roundInfo);
 
   const { mode } = roundInfo;
   const isDualMode = mode === 'DUAL';

--- a/src/components/game-room/gameScreen/RoundResultContent.tsx
+++ b/src/components/game-room/gameScreen/RoundResultContent.tsx
@@ -6,8 +6,11 @@ import { useGameRoundInfoStore } from '@/stores/websocket/useGameRoundInfoStore'
 import { useGameRoundResultStore } from '@/stores/websocket/useGameRoundResultStore';
 
 const RoundResultContent = () => {
-  const { gameRoundResult } = useGameRoundResultStore();
-  const { roundInfo } = useGameRoundInfoStore();
+  const gameRoundResult = useGameRoundResultStore(
+    state => state.gameRoundResult,
+  );
+  const roundInfo = useGameRoundInfoStore(state => state.roundInfo);
+
   const { mode } = roundInfo;
   const isDualMode = mode === 'DUAL';
 

--- a/src/components/game-room/gameScreen/RoundRolling.tsx
+++ b/src/components/game-room/gameScreen/RoundRolling.tsx
@@ -10,9 +10,10 @@ import {
 import { useGameStateStore } from '@/stores/websocket/useGameStateStore';
 
 const RoundRolling = () => {
-  const { gameRoomInfo } = useGameInfoStore();
-  const { gameState } = useGameStateStore();
-  const { roundInfo } = useGameRoundInfoStore();
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const gameState = useGameStateStore(state => state.gameState);
+  const roundInfo = useGameRoundInfoStore(state => state.roundInfo);
+
   const [isRolling, setIsRolling] = useState(true);
 
   useEffect(() => {

--- a/src/components/game-room/gameWait/ReadyPanel.tsx
+++ b/src/components/game-room/gameWait/ReadyPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { motion } from 'framer-motion';
 import Image from 'next/image';
+import { useShallow } from 'zustand/shallow';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -26,11 +27,16 @@ const ReadyPanel = ({
   roomId,
   channelId,
 }: ReadyPanelProps) => {
-  const { participantInfo, isAllReady, hostNickname } =
-    useParticipantInfoStore();
-  const { gameRoomInfo } = useGameInfoStore();
-  const { gameChattings } = useGameChatStore();
-  const { sendMessage } = useWebSocketStore();
+  const { participantInfo, isAllReady, hostNickname } = useParticipantInfoStore(
+    useShallow(state => ({
+      participantInfo: state.participantInfo,
+      isAllReady: state.isAllReady,
+      hostNickname: state.hostNickname,
+    })),
+  );
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const gameChattings = useGameChatStore(state => state.gameChattings);
+  const sendMessage = useWebSocketStore(state => state.sendMessage);
 
   const [chattingMap, setChattingMap] = useState<
     Record<string, { message: string; timestamp: number }>

--- a/src/components/game-room/scoreMap/ScoreBoardTable.tsx
+++ b/src/components/game-room/scoreMap/ScoreBoardTable.tsx
@@ -17,9 +17,11 @@ interface Participant {
 
 const ScoreboardTable = () => {
   // 실제 데이터 사용
-  const { scores } = useScoreStore();
-  const { participantInfo } = useParticipantInfoStore();
-  const { nickname: currentUser } = useNicknameStore();
+  const scores = useScoreStore(state => state.scores);
+  const participantInfo = useParticipantInfoStore(
+    state => state.participantInfo,
+  );
+  const currentUser = useNicknameStore(state => state.nickname);
 
   const [isLoading, setIsLoading] = useState(true);
   const [allPlayers, setAllPlayers] = useState<Participant[]>([]);

--- a/src/components/game-room/scoreMap/ScoreRoundInformation.tsx
+++ b/src/components/game-room/scoreMap/ScoreRoundInformation.tsx
@@ -8,7 +8,7 @@ import RoundRolling from '../gameScreen/RoundRolling';
 import YoutubePlayer from '../gameScreen/YoutubePlayer';
 
 const ScoreRoundInformation = () => {
-  const { gameState } = useGameStateStore();
+  const gameState = useGameStateStore(state => state.gameState);
 
   const containerVariants = {
     hidden: { opacity: 0 },

--- a/src/components/game-room/scoreMap/ScoreWaiting.tsx
+++ b/src/components/game-room/scoreMap/ScoreWaiting.tsx
@@ -30,9 +30,12 @@ const ScoreWaitingPanel = ({
   channelId,
 }: ScoreWaitingPanelProps) => {
   const router = useRouter();
-  const { gameRoomInfo } = useGameInfoStore();
-  const { participantInfo, hostNickname } = useParticipantInfoStore();
-  const { nickname: currentNickname } = useNicknameStore();
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const participantInfo = useParticipantInfoStore(
+    state => state.participantInfo,
+  );
+  const hostNickname = useParticipantInfoStore(state => state.hostNickname);
+  const currentNickname = useNicknameStore(state => state.nickname);
 
   const isHost = currentUserId === hostNickname;
 

--- a/src/components/game-room/scoreMap/index.tsx
+++ b/src/components/game-room/scoreMap/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { SCORE_MAP_SOUNDS } from '@/constants/config/soundConfig';
 import useSound from '@/hooks/useSound';
 import { useSoundEventStore } from '@/stores/useSoundEventStore';
 
@@ -7,8 +8,6 @@ import GameExitButton from '../GameExitButton';
 import ScoreChatBox from '../ScoreChatBox';
 import ScoreboardTable from './ScoreBoardTable';
 import ScoreRoundInformation from './ScoreRoundInformation';
-
-// 실제 경로로 수정해주세요
 
 const ScoreMap = ({
   nickname,
@@ -20,12 +19,7 @@ const ScoreMap = ({
   channelId: string;
 }) => {
   const { soundEvent, setSoundEvent } = useSoundEventStore();
-  const { play, stop } = useSound([
-    { key: 'ROULETTE', url: '/audio/playsound/roulette.mp3' },
-    { key: 'ROULETTE_RESULT', url: '/audio/playsound/roulette-result.mp3' },
-    { key: 'CORRECT', url: '/audio/playsound/correct.mp3' },
-    { key: 'WINNER', url: '/audio/playsound/winner.mp3' },
-  ]);
+  const { play, stop } = useSound(SCORE_MAP_SOUNDS);
 
   useEffect(() => {
     if (soundEvent) play(soundEvent);

--- a/src/components/game-room/scoreMap/index.tsx
+++ b/src/components/game-room/scoreMap/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { useShallow } from 'zustand/shallow';
+
 import { SCORE_MAP_SOUNDS } from '@/constants/config/soundConfig';
 import useSound from '@/hooks/useSound';
 import { useSoundEventStore } from '@/stores/useSoundEventStore';
@@ -18,7 +20,12 @@ const ScoreMap = ({
   roomId: string;
   channelId: string;
 }) => {
-  const { soundEvent, setSoundEvent } = useSoundEventStore();
+  const { soundEvent, setSoundEvent } = useSoundEventStore(
+    useShallow(state => ({
+      soundEvent: state.soundEvent,
+      setSoundEvent: state.setSoundEvent,
+    })),
+  );
   const { play, stop } = useSound(SCORE_MAP_SOUNDS);
 
   useEffect(() => {

--- a/src/components/lobby/ChatBox.tsx
+++ b/src/components/lobby/ChatBox.tsx
@@ -1,5 +1,7 @@
 import { FormEvent, useEffect, useRef, useState } from 'react';
 
+import { useShallow } from 'zustand/shallow';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useNicknameStore } from '@/stores/auth/useNicknameStore';
@@ -8,13 +10,22 @@ import { useWebSocketStore } from '@/stores/websocket/useWebsocketStore';
 import { Chatting } from '@/types/websocket';
 
 export default function ChatBox({ channelId }: { channelId: string }) {
-  const { nickname } = useNicknameStore();
-  const [newMessage, setNewMessage] = useState<string>('');
-  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const nickname = useNicknameStore(state => state.nickname);
 
   const { sendMessage, updateSubscription, isConnected, checkSubscription } =
-    useWebSocketStore();
-  const { publicChattings } = usePublicChatStore();
+    useWebSocketStore(
+      useShallow(state => ({
+        sendMessage: state.sendMessage,
+        updateSubscription: state.updateSubscription,
+        isConnected: state.isConnected,
+        checkSubscription: state.checkSubscription,
+      })),
+    );
+  const publicChattings = usePublicChatStore(state => state.publicChattings);
+
+  const [newMessage, setNewMessage] = useState<string>('');
+
+  const chatContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isConnected && !checkSubscription('channel')) {

--- a/src/components/room/RoomContainer.tsx
+++ b/src/components/room/RoomContainer.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useRouter } from 'next/router';
+import { useShallow } from 'zustand/shallow';
 
 import BackgroundMusic from '@/components/common/BackgroundMusic';
 import ChatBox from '@/components/game-room/ChatBox';
@@ -23,10 +24,16 @@ export default function GameRoomContainer({
 }: GameRoomServerProps) {
   const router = useRouter();
 
-  const { nickname } = useNicknameStore();
-  const { isConnected, updateSubscription, sendMessage } = useWebSocketStore();
-  const { gameRoomInfo } = useGameInfoStore();
-  const { gameState } = useGameStateStore();
+  const nickname = useNicknameStore(state => state.nickname);
+  const { isConnected, updateSubscription, sendMessage } = useWebSocketStore(
+    useShallow(state => ({
+      isConnected: state.isConnected,
+      updateSubscription: state.updateSubscription,
+      sendMessage: state.sendMessage,
+    })),
+  );
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+  const gameState = useGameStateStore(state => state.gameState);
 
   useEffect(() => {
     if (isConnected) {

--- a/src/components/room/RoomFormDialog.tsx
+++ b/src/components/room/RoomFormDialog.tsx
@@ -40,13 +40,15 @@ export default function RoomFormDialog({
   buttonClassName = 'bg-[#9FFCFE] text-black hover:bg-opacity-80 rounded-full px-6',
   onDialogClose,
 }: RoomFormDialogProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const { gameRoomInfo } = useGameInfoStore();
   const router = useRouter();
+  const { channelId } = router.query;
+
+  const gameRoomInfo = useGameInfoStore(state => state.gameRoomInfo);
+
+  const [isOpen, setIsOpen] = useState(false);
 
   // 대화상자가 열릴 때마다 새로 설정할 초기 데이터 상태
   const [initialData, setInitialData] = useState<InitialDataType | null>(null);
-  const { channelId } = router.query;
 
   // isOpen이 true로 바뀔 때에만 initialData 설정
   useEffect(() => {

--- a/src/constants/config/soundConfig.ts
+++ b/src/constants/config/soundConfig.ts
@@ -1,0 +1,20 @@
+export const BOARD_MAP_SOUNDS = [
+  { key: 'EVENT_CARD', url: '/audio/playsound/event-card.mp3' },
+  { key: 'JUMP', url: '/audio/playsound/jump.mp3' },
+  { key: 'ROULETTE', url: '/audio/playsound/roulette.mp3' },
+  { key: 'ROULETTE_RESULT', url: '/audio/playsound/roulette-result.mp3' },
+  { key: 'ROULETTE_123', url: '/audio/playsound/roulette-123.mp3' },
+  {
+    key: 'ROULETTE_123_RESULT',
+    url: '/audio/playsound/roulette-123-result.mp3',
+  },
+  { key: 'CORRECT', url: '/audio/playsound/correct.mp3' },
+  { key: 'WINNER', url: '/audio/playsound/winner.mp3' },
+];
+
+export const SCORE_MAP_SOUNDS = [
+  { key: 'ROULETTE', url: '/audio/playsound/roulette.mp3' },
+  { key: 'ROULETTE_RESULT', url: '/audio/playsound/roulette-result.mp3' },
+  { key: 'CORRECT', url: '/audio/playsound/correct.mp3' },
+  { key: 'WINNER', url: '/audio/playsound/winner.mp3' },
+];

--- a/src/stores/websocket/useGameDiceStore.ts
+++ b/src/stores/websocket/useGameDiceStore.ts
@@ -19,8 +19,8 @@ export const useGameDiceStore = create<GameDiceStore>(set => ({
   isActiveDice: false,
   diceUsername: '',
   diceTotalmovement: null,
-  setIsActiveDice: (isActiceDice: boolean) => {
-    set({ isActiveDice: isActiceDice });
+  setIsActiveDice: (isActiveDice: boolean) => {
+    set({ isActiveDice });
   },
   setDice: (movement: MovementInfo) => {
     set({

--- a/src/stores/websocket/usePublicChatStore.ts
+++ b/src/stores/websocket/usePublicChatStore.ts
@@ -4,7 +4,7 @@ import { Chatting } from '@/types/websocket';
 
 export interface PublicChatStore {
   publicChattings: Chatting[];
-  setPublicChattings: (publicChatting: Chatting) => void;
+  addPublicChattings: (publicChatting: Chatting) => void;
   resetPublicChatStore: () => void;
 }
 
@@ -14,7 +14,7 @@ const initialState = {
 
 export const usePublicChatStore = create<PublicChatStore>((set, get) => ({
   publicChattings: [],
-  setPublicChattings: (publicChatting: Chatting) => {
+  addPublicChattings: (publicChatting: Chatting) => {
     set({ publicChattings: [...get().publicChattings, publicChatting] });
   },
 

--- a/src/stores/websocket/useScoreStore.ts
+++ b/src/stores/websocket/useScoreStore.ts
@@ -15,12 +15,18 @@ export const useScoreStore = create<ScoreStore>(set => ({
   setScores: initialScores => set({ scores: initialScores }),
 
   updateScore: (username, score) =>
-    set(state => ({
-      scores: {
-        ...state.scores,
-        [username]: score,
-      },
-    })),
+    set(state => {
+      const current = state.scores[username];
+      if (current === score) {
+        return {};
+      }
+      return {
+        scores: {
+          ...state.scores,
+          [username]: score,
+        },
+      };
+    }),
 
   resetScores: () => set({ scores: {} }),
 }));

--- a/src/stores/websocket/useWebsocketStore.ts
+++ b/src/stores/websocket/useWebsocketStore.ts
@@ -96,7 +96,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
         `/topic/channel/${channelId}`,
         message => {
           const { response } = JSON.parse(message.body);
-          usePublicChatStore.getState().setPublicChattings(response);
+          usePublicChatStore.getState().addPublicChattings(response);
         },
         {
           Authorization: `Bearer ${getCookie(COOKIE_NAME)}`,


### PR DESCRIPTION
## 기존 방식
```js
 const scores = useScoreStore();

 const { targetUser, triggerUser, eventType } = useGameBubbleStore();
```
주스탄드는 useScoreStore()처럼 인자 없이 훅을 호출할 경우 해당 store 전체를 구독한다.
만약 useScoreStore 안에 scores 말고도 scoreRank 등의 다른 상태값이 변경되면 우리는 scoreRank를 불러오지 않았더라도 
 const scores = useScoreStore();로 인해 이 컴포넌트가 리렌더링된다.

## 해결방법
이런 문제를 해결하기 위해 다음과 같은 세가지 방법을 사용한다.
- store를 작은 단위로 분리한다. (기존 반영)
- selector를 활용해 필요한 값만 구독한다.  (`이번 작업`)
- 여러 값을 구독할 경우 shallow를 이용해 얕은 비교로 리렌더링 최적화 (`이번 작업`)

```js
// selector 사용
 const scores = useScoreStore(state => state.scores);
 
// selector + shallow
  const { targetUser, triggerUser, eventType } = useGameBubbleStore(
    useShallow(state => ({
      targetUser: state.targetUser,
      triggerUser: state.triggerUser,
      eventType: state.eventType,
    })),
  );
```
이처럼 단일값을 호출하는 경우는 selector를 
여러 값을 객체 형태로 사용하는 경우는 selector + shallow를 사용해준다.

이 작업을 통해 리렌더링 범위를 명확히 제한해주었다.